### PR TITLE
Various fixups

### DIFF
--- a/src/plugins/__intit__.py
+++ b/src/plugins/__intit__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__import__('pkg_resources').declare_namespace(__name__)

--- a/src/plugins/analytics_plugin.py
+++ b/src/plugins/analytics_plugin.py
@@ -71,13 +71,12 @@ def tasks_report(session) -> Any:
 
 def format_db_response(resp):
     log.info(resp)
-    task_summary_arr = resp["tasks_report"]
+    task_summary = resp["tasks_report"]
 
     key_conversion = {"success": "total_success", "failed": "total_failed"}
     temp_result = {}
-    for date_task_summary in task_summary_arr:
-        fieldName = key_conversion[date_task_summary["event"]]
-        temp_result[fieldName] = date_task_summary["totalCount"]
+    for query_field in task_summary.keys():
+        temp_result[key_conversion[query_field]] = task_summary[query_field]
 
     return temp_result
 
@@ -109,7 +108,7 @@ class AstronomerAnalytics(AppBuilderBaseView):
                 {
                     "name": "tasks",
                     "description": "return number of successful and failed tasks for specified time period",
-                    "airflow_version": airflow_version,
+                    "airflow_version": "2.x",
                     "http_method": ["GET"],
                     "arguments": [
                         {

--- a/src/plugins/analytics_plugin.py
+++ b/src/plugins/analytics_plugin.py
@@ -1,13 +1,14 @@
 import logging
 from typing import Any
 
-from sqlalchemy import text
+from sqlalchemy import and_, distinct, func, text
+from sqlalchemy.orm import aliased
 
 from flask import Blueprint, request
 from flask_appbuilder import BaseView as AppBuilderBaseView
 from flask_appbuilder import expose
 
-from airflow import configuration
+from airflow import __version__ as airflow_version, configuration
 from airflow.models import Log, TaskInstance
 from airflow.plugins_manager import AirflowPlugin
 from airflow.utils.session import provide_session
@@ -25,91 +26,67 @@ bp = Blueprint(
     static_folder="static",
     static_url_path="/static/",
 )
-airflow_webserver_base_url = configuration.get("webserver", "BASE_URL")
 
-apis_metadata = [
-    {
-        "name": "tasks",
-        "description": "return number of successful and failed tasks for specified time period",
-        "airflow_version": "xxx",  # airflow.version something like that
-        "http_method": ["GET"],
-        "arguments": [
-            {
-                "name": "startDate",
-                "description": "The start date of the task period (Example: YYYY-MM-DD )",
-                "form_input_type": "text",
-                "required": True,
-            },
-            {
-                "name": "endDate",
-                "description": "The end date of the task period (Example: YYYY-MM-DD)",
-                "form_input_type": "text",
-                "required": True,
-            },
-        ],
-    }
-]
+airflow_webserver_base_url = configuration.get("webserver", "BASE_URL")
 
 
 @provide_session
-def dags_report(session) -> Any:
+def tasks_report(session) -> Any:
     untrusted_start_date = request.args.get("startDate")  # 2022-08-01
     untrusted_end_date = request.args.get("endDate")  # 2022-08-30
     try:
-        parse(untrusted_start_date)
-        parse(untrusted_end_date)
-    except ValueError:
-        log.error("The string is not a date ")
+        start_date = parse(untrusted_start_date)
+        end_date = parse(untrusted_end_date)
+    except ValueError as e:
+        log.error(f"The string is not a date: {e}")
+        raise e
     else:
+        log_success = aliased(Log, name="log_success")
+        log_failed = aliased(Log, name="log_failed")
         # remove the dummy operator and the astronomer_monitoring_dag that is added in runtime from task count
         query = (
             session.query(
-                Log.event,
-                func.count(Log.event).label("totalCount"),
+                func.count(distinct(log_success.id)).label("total_success"),
+                func.count(distinct(log_failed.id)).label("total_failed"),
             )
-            .join(
-                TaskInstance.event.in_(
-                    TaskInstanceState.SUCCESS, TaskInstanceState.FAILED
+            .select_from(TaskInstance)
+            .outerjoin(
+                log_success,
+                and_(
+                    log_success.task_id == TaskInstance.task_id,
+                    log_success.dttm >= start_date,
+                    log_success.dttm <= end_date,
+                    log_success.dag_id != "astronomer_monitoring_dag",
+                    log_success.event == TaskInstanceState.SUCCESS,
                 ),
-                TaskInstance.operator != "DummyOperator",
-                TaskInstance.task_id == Log.task_id,
+                isouter=True,
             )
-            .filter(
-                Log.dttm >= start_date,
-                Log.dttm <= end_date,
-                Log.dag_id != "astronomer_monitoring_dag",
+            .outerjoin(
+                log_failed,
+                and_(
+                    log_failed.task_id == TaskInstance.task_id,
+                    log_failed.dttm >= start_date,
+                    log_failed.dttm <= end_date,
+                    log_failed.dag_id != "astronomer_monitoring_dag",
+                    log_success.event == TaskInstanceState.FAILED,
+                ),
+                isouter=True,
             )
-            .group_by(Log.event)
+            .filter(TaskInstance.operator != "DummyOperator")
         )
 
-        return [dict(result_row) for result_row in session.query(query).all()]
-
-
-def format_db_response(resp):
-    log.info(resp)
-    task_summary_arr = resp["dags_report"]
-
-    key_conversion = {"success": "total_success", "failed": "total_failed"}
-    temp_result = {}
-    for date_task_summary in task_summary_arr:
-        fieldName = key_conversion[date_task_summary["event"]]
-        temp_result[fieldName] = date_task_summary["totalcount"]
-
-    return temp_result
-
-
-rest_api_endpoint = "/astronomeranalytics/api/v1/"
+        return dict(session.query(query).one())
 
 
 def try_reporter(reporter_func):
     try:
         rtn = {
-            reporter_func.__name__: reporter_func(),
+            "results": reporter_func(),
         }
     except Exception as e:
         logging.exception(f"Failed reporting {reporter_func.__name__}")
         rtn = {
-            reporter_func.__name__: str(e),
+            "error": str(e),
         }
     return rtn
 
@@ -123,31 +100,48 @@ class AstronomerAnalytics(AppBuilderBaseView):
         return self.render_template(
             "/analytics_plugin/index.html",
             airflow_webserver_base_url=airflow_webserver_base_url,
-            rest_api_endpoint=rest_api_endpoint,
-            apis_metadata=apis_metadata,
+            rest_api_endpoint="/astronomeranalytics/api/v1/",
+            apis_metadata=[
+                {
+                    "name": "tasks",
+                    "description": "return number of successful and failed tasks for specified time period",
+                    "airflow_version": airflow_version,
+                    "http_method": ["GET"],
+                    "arguments": [
+                        {
+                            "name": "startDate",
+                            "description": "The start date of the task period (Example: YYYY-MM-DD )",
+                            "form_input_type": "text",
+                            "required": True,
+                        },
+                        {
+                            "name": "endDate",
+                            "description": "The end date of the task period (Example: YYYY-MM-DD)",
+                            "form_input_type": "text",
+                            "required": True,
+                        },
+                    ],
+                }
+            ],
         )
 
     @expose("api/v1/tasks")
     def tasks(self):
-        dags = try_reporter(dags_report)
-
-        if dags["dags_report"] == None:
-            return {
-                "message": "Invalid date",
-            }
-        return {f"dags": format_db_response(dags)}
+        return {
+            "tasks": try_reporter(tasks_report),
+        }
 
 
 # Defining the plugin class
 class AstronomerPlugin(AirflowPlugin):
-    name = "AstronomerAnalytics"
+    name = "Astronomer Analytics"
     hooks = []
     macros = []
     flask_blueprints = [bp]
     appbuilder_views = [
         {
-            "name": "API's",
-            "category": "AstronomerAnalytics",
+            "name": "APIs",
+            "category": "Astronomer Analytics",
             "view": AstronomerAnalytics(),
         }
     ]

--- a/src/plugins/analytics_plugin.py
+++ b/src/plugins/analytics_plugin.py
@@ -1,17 +1,22 @@
-from pickle import NONE
-from typing import Any 
-from dateutil.parser import parse
-
 import logging
+from typing import Any
+
 from sqlalchemy import text
 
-from airflow.plugins_manager import AirflowPlugin
 from flask import Blueprint, request
-from flask_appbuilder import BaseView as AppBuilderBaseView 
+from flask_appbuilder import BaseView as AppBuilderBaseView
 from flask_appbuilder import expose
+
 from airflow import configuration
-log = logging.getLogger(__name__)
+from airflow.models import Log, TaskInstance
+from airflow.plugins_manager import AirflowPlugin
+from airflow.utils.session import provide_session
+from airflow.utils.state import TaskInstanceState
+from airflow.utils.timezone import parse
+
 __version__ = "1.0.0"
+
+log = logging.getLogger(__name__)
 
 bp = Blueprint(
     "astronomer_analytics",
@@ -26,90 +31,51 @@ apis_metadata = [
         {
         "name": "tasks",
         "description": "return number of successful and failed tasks for specified time period",
-        "airflow_version": "xxx",
+        "airflow_version": "xxx",  # airflow.version something like that
         "http_method": ["GET"],
         "arguments": [
            {"name": "startDate",
                 "description": "The start date of the task period (Example: YYYY-MM-DD )", "form_input_type": "text", "required": True},
            {"name": "endDate",
                 "description": "The end date of the task period (Example: YYYY-MM-DD)", "form_input_type": "text", "required": True},
- 
+
        ]
     }
 ]
-try:
-    from airflow.utils.session import provide_session
-except:
-    from typing import Callable, Iterator, TypeVar
 
-    import contextlib
-    from functools import wraps
-    from inspect import signature
-
-    from airflow import DAG, settings
-
-    RT = TypeVar("RT")
-
-    def find_session_idx(func: Callable[..., RT]) -> int:
-        """Find session index in function call parameter."""
-        func_params = signature(func).parameters
-        try:
-            # func_params is an ordered dict -- this is the "recommended" way of getting the position
-            session_args_idx = tuple(func_params).index("session")
-        except ValueError:
-            raise ValueError(f"Function {func.__qualname__} has no `session` argument") from None
-
-        return session_args_idx
-
-    @contextlib.contextmanager
-    def create_session():
-        """Contextmanager that will create and teardown a session."""
-        session = settings.Session
-        try:
-            yield session
-            session.commit()
-        except Exception:
-            session.rollback()
-            raise
-        finally:
-            session.close()
-
-    def provide_session(func: Callable[..., RT]) -> Callable[..., RT]:
-        """
-        Function decorator that provides a session if it isn't provided.
-        If you want to reuse a session or run the function as part of a
-        database transaction, you pass it to the function, if not this wrapper
-        will create one and close it for you.
-        """
-        session_args_idx = find_session_idx(func)
-
-        @wraps(func)
-        def wrapper(*args, **kwargs) -> RT:
-            if "session" in kwargs or session_args_idx < len(args):
-                return func(*args, **kwargs)
-            else:
-                with create_session() as session:
-                    return func(*args, session=session, **kwargs)
-
-        return wrapper
 
 @provide_session
 def dags_report(session) -> Any:
-    start_date = request.args.get("startDate") # 2022-08-01
-    end_date = request.args.get("endDate") #2022-08-30
+    untrusted_start_date = request.args.get("startDate") # 2022-08-01
+    untrusted_end_date = request.args.get("endDate") #2022-08-30
     try:
-        parse(start_date)
-        parse(end_date)
-        # remove the dummy operator and the astronomer_monitoring_dag that is added in runtime from task count
-        sql = text(
-            f"""
-            select event, count(*) as totalCount from log l join task_instance ti on event in ('success', 'failed') and l.dttm >= '{start_date}' and l.dttm <= '{end_date}' and ti.operator != 'DummyOperator' and l.dag_id != 'astronomer_monitoring_dag' and ti.task_id = l.task_id group by event
-        """
-        )
-        return [dict(r) for r in session.execute(sql)]
-
+        parse(untrusted_start_date)
+        parse(untrusted_end_date)
     except ValueError:
         log.error("The string is not a date ")
+    else:
+        # remove the dummy operator and the astronomer_monitoring_dag that is added in runtime from task count
+        query = (
+            session.query(
+                Log.event,
+                func.count(Log.event).label("totalCount"),
+            )
+            .join(
+                TaskInstance.event.in_(TaskInstanceState.SUCCESS, TaskInstanceState.FAILED),
+                TaskInstance.operator != 'DummyOperator',
+                TaskInstance.task_id == Log.task_id,
+            )
+            .filter(
+                Log.dttm >= start_date,
+                Log.dttm <= end_date,
+                Log.dag_id != "astronomer_monitoring_dag",
+            )
+            .group_by(Log.event)
+        )
+
+        return [dict(result_row) for result_row in session.query(query).all()]
+
+
 
 def format_db_response(resp):
     log.info(resp)
@@ -121,43 +87,51 @@ def format_db_response(resp):
     }
     temp_result = {}
     for date_task_summary in task_summary_arr:
-            fieldName = key_conversion[date_task_summary['event']]
-            temp_result[fieldName]=date_task_summary['totalcount']
+        fieldName = key_conversion[date_task_summary['event']]
+        temp_result[fieldName]=date_task_summary['totalcount']
 
     return temp_result
 
+
 rest_api_endpoint = "/astronomeranalytics/api/v1/"
+
+
+def try_reporter(reporter_func):
+    try:
+        rtn = {
+            reporter_func.__name__: reporter_func(),
+        }
+    except Exception as e:
+        logging.exception(f"Failed reporting {reporter_func.__name__}")
+        rtn = {
+            reporter_func.__name__: str(e),
+        }
+    return rtn
+
+
 # Creating a flask appbuilder BaseView
 class AstronomerAnalytics(AppBuilderBaseView):
-    default_view = "index" 
+    default_view = "index"
 
     @expose("/")
     def index(self):
-            return self.render_template("/analytics_plugin/index.html",
-                airflow_webserver_base_url=airflow_webserver_base_url,
-                rest_api_endpoint=rest_api_endpoint,
-                apis_metadata=apis_metadata,
-            )        
+        return self.render_template("/analytics_plugin/index.html",
+            airflow_webserver_base_url=airflow_webserver_base_url,
+            rest_api_endpoint=rest_api_endpoint,
+            apis_metadata=apis_metadata,
+        )
 
     @expose("api/v1/tasks")
     def tasks(self):
-      def try_reporter(r):
-        try:
-            return {r.__name__: r()}
-        except Exception as e:
-            logging.exception(f"Failed reporting {r.__name__}")
-            return {r.__name__: str(e)}
-      dags = try_reporter(dags_report) 
-      if dags["dags_report"] == None:
-        return {"message": "Invalid date"}
-      return  { f"dags": format_db_response(dags) }
+        dags = try_reporter(dags_report)
 
-v_appbuilder_view = AstronomerAnalytics()
-v_appbuilder_package = {
-    "name": "API's",
-    "category": "AstronomerAnalytics",
-    "view": v_appbuilder_view,
-}
+        if dags["dags_report"] == None:
+            return {
+                "message": "Invalid date",
+            }
+        return  {
+            f"dags": format_db_response(dags)
+        }
 
 
 # Defining the plugin class
@@ -170,10 +144,9 @@ class AstronomerPlugin(AirflowPlugin):
         {
             "name": "API's",
             "category": "AstronomerAnalytics",
-            "view": v_appbuilder_view,
-        },
+            "view": AstronomerAnalytics(),
+        }
     ]
     appbuilder_menu_items = []
     global_operator_extra_links = []
     operator_extra_links = []
-

--- a/src/plugins/templates/analytics_plugin/index.html
+++ b/src/plugins/templates/analytics_plugin/index.html
@@ -70,19 +70,11 @@
 
     <h6>Available in Airflow Version: <b>{{api_metadata.airflow_version}}</b></h6>
     <div>
-        <form method="{{api_metadata.http_method[0]}}"
-              target="_blank"
-              action="{{rest_api_endpoint}}{{api_metadata.name}}"
-              enctype="{{ api_metadata.form_enctype if api_metadata.form_enctype else 'application/x-www-form-urlencoded' }}"
-              onsubmit="return disableEmptyFields(this)"
-        >
-
             <table>
                 {% if api_metadata.arguments|length > 0 or api_metadata.post_arguments|length > 0 %}
 
                     <tr>
                         <th>Argument Name</th>
-                        <th>Input</th>
                         <th>Required</th>
                         <th>Description</th>
                     </tr>
@@ -98,8 +90,6 @@
                             {%endfor%}
                          {%endfor%}
                         </td>
-                        {% else %}
-                        <td><input type="{{argument.form_input_type}}" name="{{argument.name}}"/></td>
                         {% endif %}
                         <td>{{argument.required}}</td>
                         <td>{{argument.description}}</td>
@@ -118,11 +108,7 @@
                     <b>No Arguments</b>
                 {% endif %}
 
-                <tr>
-                    <td colspan="2"><input type="submit" class="btn btn-primary" value="Execute"/></td>
-                </tr>
             </table>
-        </form>
     </div>
 </div>
 <br/>


### PR DESCRIPTION
This PR formats the Python code with Black (except for `setup.py`), and cleans up the database query, the FAB view, and the returned results dictionary a bit.

I think I see what you're trying to do with making it easy to add additional analytics/checks in the future, so I tried to keep that structure the same. But I did tweak the format of the returned results a bit. If you must remain reverse compatible, I can do so, just let me know.

I also didn't really take a look at or change the index view or the template at all - they might need to change to accommodate the new response format.

Aside from the database query, I did not test this, so please do some manual testing with this if you can. I'd be happy to sit on a call and assist with that.

Also, we should explicitly define what versions of Airflow this works with so we know what functions, etc. we need to vendor in and what we can count on being in Airflow itself. I think there's a way to specify the supported version(s) of Airflow as dependencies of this plugin, so we should do that if we can.

Happy to change anything else that you don't like, not trying to take over this project, just propose some improvements where I can. 😄

Future work (in other PRs):

* [ ] Clean up the `setup.py`, `setup.cfg` and migrate the data in them to just being in `pyproject.toml` if possible
* [ ] Get pre-commit running checks on this just to keep the code nice, idiomatic, and clean
* [ ] CI somehow, possibly in conjunction with astro-runtime, Turbulence, or something else. I don't see a whole lot of value in CI with ap-airflow, since that _should_ (<-- famous last word) only see bugfix releases for that.